### PR TITLE
chage hover color for public link in dark mode 

### DIFF
--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -2,7 +2,7 @@
   "id": "flotiq.content-publishing",
   "name": "Content Preview",
   "description": "The plugin generates links that let you open drafts and public versions of pages directly from the editor. With one click, users can quickly save and open the draft version, streamlining their workflow for maximum efficiency. It works best with Next.js-based sites that use draft mode.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "repository": "https://github.com/flotiq/flotiq-ui-plugin-content-publishing",
   "url": "https://localhost:3053/index.js",
   "permissions": [

--- a/plugins/styles/index.css
+++ b/plugins/styles/index.css
@@ -122,10 +122,7 @@
   color: white;
 }
 
-.mode-dark .plugin-preview-links__preview-link svg {
-  filter: contrast(0) brightness(100);
-}
-
+.mode-dark .plugin-preview-links__preview-link svg,
 .mode-dark .plugin-preview-links__public-link svg {
   filter: contrast(0) brightness(100);
 }
@@ -133,8 +130,16 @@
 .mode-dark
   .plugin-preview-links__public-link:not(
     .plugin-preview-links__link--disabled
+  ):hover
+  svg {
+  filter: none;
+}
+
+.mode-dark
+  .plugin-preview-links__public-link:not(
+    .plugin-preview-links__link--disabled
   ):hover {
-  color: #015bd7;
+  color: #0083fc;
 }
 
 @media (max-width: 1536px) {


### PR DESCRIPTION
Changes:

- lighter color when hovering public link in dark mode